### PR TITLE
Remove unnecessary destructor

### DIFF
--- a/bip/t3dn_bip/previews.py
+++ b/bip/t3dn_bip/previews.py
@@ -216,10 +216,6 @@ class ImagePreviewCollection:
             self._event.set()
             self._event = None
 
-    def __del__(self):
-        '''Called when collection is garbage collected.'''
-        self.close()
-
 
 def new(
     max_size: tuple = (128, 128),


### PR DESCRIPTION
It seems closing the collection in the destructor is too late, which causes an error.
Besides, we close it manually in unregister anyway.

Here's the exception:
```
Exception ignored in: <function ImagePreviewCollection.__del__ at 0x000001A45993B168>
Traceback (most recent call last):
  File "C:\Users\Jorijn\AppData\Roaming\Blender Foundation\Blender\2.92\scripts\addons\t3dn_bip_example\t3dn_bip\previews.py", line 221, in __del__
  File "C:\Users\Jorijn\AppData\Roaming\Blender Foundation\Blender\2.92\scripts\addons\t3dn_bip_example\t3dn_bip\previews.py", line 204, in close
  File "C:\Blender\Blender 2.92\2.92\scripts\modules\bpy\utils\previews.py", line 115, in close
KeyError: ('0x1a45992a708',)
```
