### PR TITLE
Clear previews on shift click

### DIFF
--- a/bip/t3dn_bip/__init__.py
+++ b/bip/t3dn_bip/__init__.py
@@ -1,3 +1,3 @@
 '''Load image previews in parallel and in any resolution. Supports BIP files.'''
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'

--- a/bip/t3dn_bip/previews.py
+++ b/bip/t3dn_bip/previews.py
@@ -10,13 +10,15 @@ from time import time
 from typing import ItemsView, Iterator, KeysView, ValuesView
 from .utils import support_pillow, can_load, load_file, tag_redraw
 
+WARNINGS = True
+
 
 class ImagePreviewCollection:
     '''Dictionary-like class of previews.'''
 
     def __init__(self, max_size: tuple = (128, 128), lazy_load: bool = True):
         '''Create collection and start internal timer.'''
-        if not support_pillow():
+        if WARNINGS and not support_pillow():
             print('Pillow is not installed, therefore:')
             print('-   BIP images load without scaling.')
 

--- a/bip_converter/t3dn_bip_converter/__init__.py
+++ b/bip_converter/t3dn_bip_converter/__init__.py
@@ -1,3 +1,3 @@
 '''Convert between BIP files and various image formats.'''
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'

--- a/example/t3dn_bip_example/ops.py
+++ b/example/t3dn_bip_example/ops.py
@@ -10,17 +10,20 @@ class T3DN_OT_bip_example_install_pillow(bpy.types.Operator, InstallPillow):
 class T3DN_OT_bip_example_load_previews(bpy.types.Operator):
     bl_idname = 't3dn.bip_example_load_previews'
     bl_label = 'Load Previews'
-    bl_description = 'Load BIP or JPG image previews'
+    bl_description = '.\n'.join((
+        'Load BIP or JPG image previews',
+        'Shift click to reload previews',
+    ))
     bl_options = {'REGISTER', 'INTERNAL'}
 
     type: bpy.props.StringProperty()
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event) -> set:
-        paths = previews.folder.joinpath(self.type).glob(f'*.{self.type}')
-        previews.collection.clear()
+        if event.shift:
+            previews.collection.clear()
 
-        for path in list(paths)[:96]:
-            previews.collection.load(path.name, str(path), 'IMAGE')
+        paths = previews.folder.joinpath(self.type).glob(f'*.{self.type}')
+        self.paths = [str(path) for path in paths][:96]
 
         return context.window_manager.invoke_popup(self, width=1700)
 
@@ -28,7 +31,8 @@ class T3DN_OT_bip_example_load_previews(bpy.types.Operator):
         layout = self.layout
         grid = layout.grid_flow(row_major=True, columns=12)
 
-        for preview in previews.collection.values():
+        for path in self.paths:
+            preview = previews.collection.load_safe(path, path, 'IMAGE')
             grid.template_icon(preview.icon_id, scale=6.8)
 
     def execute(self, context: bpy.types.Context) -> set:
@@ -38,17 +42,21 @@ class T3DN_OT_bip_example_load_previews(bpy.types.Operator):
 class T3DN_OT_bip_example_load_alpha(bpy.types.Operator):
     bl_idname = 't3dn.bip_example_load_alpha'
     bl_label = 'Load Alpha Previews'
-    bl_description = 'Load BIP and PNG with transparency'
+    bl_description = '.\n'.join((
+        'Load BIP and PNG with transparency',
+        'Shift click to reload previews',
+    ))
     bl_options = {'REGISTER', 'INTERNAL'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event) -> set:
-        previews.collection.clear()
+        if event.shift:
+            previews.collection.clear()
 
         bip = str(previews.folder.joinpath('alpha', 'rainbow.bip'))
         png = str(previews.folder.joinpath('alpha', 'rainbow.png'))
 
-        self.bip = previews.collection.load('bip', bip, 'IMAGE')
-        self.png = previews.collection.load('png', png, 'IMAGE')
+        self.bip = previews.collection.load_safe(bip, bip, 'IMAGE')
+        self.png = previews.collection.load_safe(png, png, 'IMAGE')
 
         return context.window_manager.invoke_popup(self, width=300)
 
@@ -70,19 +78,23 @@ class T3DN_OT_bip_example_load_alpha(bpy.types.Operator):
 class T3DN_OT_bip_example_load_misc(bpy.types.Operator):
     bl_idname = 't3dn.bip_example_load_misc'
     bl_label = 'Load Misc Previews'
-    bl_description = 'Load movie, blend, and font previews'
+    bl_description = '.\n'.join((
+        'Load movie, blend, and font previews',
+        'Shift click to reload previews',
+    ))
     bl_options = {'REGISTER', 'INTERNAL'}
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event) -> set:
-        previews.collection.clear()
+        if event.shift:
+            previews.collection.clear()
 
         movie = str(previews.folder.joinpath('misc', 'cube.mp4'))
         blend = str(previews.folder.joinpath('misc', 'monkey.blend'))
         font = str(previews.folder.joinpath('misc', 'courier.ttf'))
 
-        self.movie = previews.collection.load('movie', movie, 'MOVIE')
-        self.blend = previews.collection.load('blend', blend, 'BLEND')
-        self.font = previews.collection.load('font', font, 'FONT')
+        self.movie = previews.collection.load_safe(movie, movie, 'MOVIE')
+        self.blend = previews.collection.load_safe(blend, blend, 'BLEND')
+        self.font = previews.collection.load_safe(font, font, 'FONT')
 
         return context.window_manager.invoke_popup(self, width=800)
 


### PR DESCRIPTION
Before it would just always do it.
Turns out load_safe is very useful.
Added a note about it to the tooltips also.