### PR TITLE
Only include one image if size is 32x32

### DIFF
--- a/bip/t3dn_bip/__init__.py
+++ b/bip/t3dn_bip/__init__.py
@@ -1,3 +1,3 @@
 '''Load image previews in parallel and in any resolution. Supports BIP files.'''
 
-__version__ = '0.0.9'
+__version__ = '0.1.0'

--- a/bip_converter/t3dn_bip_converter/__init__.py
+++ b/bip_converter/t3dn_bip_converter/__init__.py
@@ -1,3 +1,3 @@
 '''Convert between BIP files and various image formats.'''
 
-__version__ = '0.0.9'
+__version__ = '0.1.0'

--- a/bip_converter/t3dn_bip_converter/convert.py
+++ b/bip_converter/t3dn_bip_converter/convert.py
@@ -31,7 +31,10 @@ def _image_to_bip(src: Union[str, Path], dst: Union[str, Path]):
         image = image.transpose(Image.FLIP_TOP_BOTTOM)
         image = image.convert('RGBA').convert('RGBa')
 
-        images = [image.resize(size=(32, 32)), image]
+        if image.size == (32, 32):
+            images = [image]
+        else:
+            images = [image.resize(size=(32, 32)), image]
         contents = [compress(image.tobytes()) for image in images]
 
         with open(dst, 'wb') as output:


### PR DESCRIPTION
There's no need to store a low and high res version of an image that only has a low res.