### PR TITLE
Python exe

### DIFF
--- a/bip/t3dn_bip/__init__.py
+++ b/bip/t3dn_bip/__init__.py
@@ -1,3 +1,3 @@
 '''Load image previews in parallel and in any resolution. Supports BIP files.'''
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/bip/t3dn_bip/ops.py
+++ b/bip/t3dn_bip/ops.py
@@ -18,8 +18,8 @@ class InstallPillow:
 
     def execute(self: bpy.types.Operator, context: bpy.types.Context) -> set:
         if install_pillow():
-            self.report({'INFO'}, 'Pillow was installed successfully')
+            self.report({'INFO'}, 'Successfully installed Pillow')
         else:
-            self.report({'WARNING'}, 'Pillow failed to install')
+            self.report({'WARNING'}, 'Failed to install Pillow')
 
         return {'FINISHED'}

--- a/bip/t3dn_bip/utils.py
+++ b/bip/t3dn_bip/utils.py
@@ -21,6 +21,11 @@ except ImportError:
 
 def support_pillow() -> bool:
     '''Check whether Pillow is installed.'''
+    global Image
+
+    if not Image and 'PIL' in sys.modules:
+        from PIL import Image
+
     return bool(Image)
 
 

--- a/bip/t3dn_bip/utils.py
+++ b/bip/t3dn_bip/utils.py
@@ -31,7 +31,7 @@ def support_pillow() -> bool:
 
 def install_pillow() -> bool:
     '''Install Pillow and import the Image module.'''
-    if Path(sys.executable).stem.lower() == 'python':
+    if 'python' in Path(sys.executable).stem.lower():
         exe = sys.executable
     else:
         exe = bpy.app.binary_path_python

--- a/bip/t3dn_bip/utils.py
+++ b/bip/t3dn_bip/utils.py
@@ -26,16 +26,17 @@ def support_pillow() -> bool:
 
 def install_pillow() -> bool:
     '''Install Pillow and import the Image module.'''
-    command = [sys.executable, '-m', 'ensurepip']
-    options = ['--user', '--upgrade', '--default-pip']
+    if Path(sys.executable).stem.lower() == 'python':
+        exe = sys.executable
+    else:
+        exe = bpy.app.binary_path_python
 
-    if subprocess.call(args=command + options, timeout=60 * 10):
+    args = [exe, '-m', 'ensurepip', '--user', '--upgrade', '--default-pip']
+    if subprocess.call(args=args, timeout=600):
         return False
 
-    command = [sys.executable, '-m', 'pip']
-    options = ['install', '--user', '--upgrade', 'Pillow']
-
-    if subprocess.call(args=command + options, timeout=60 * 10):
+    args = [exe, '-m', 'pip', 'install', '--user', '--upgrade', 'Pillow']
+    if subprocess.call(args=args, timeout=600):
         return False
 
     name = 'PIL'

--- a/bip_converter/t3dn_bip_converter/__init__.py
+++ b/bip_converter/t3dn_bip_converter/__init__.py
@@ -1,3 +1,3 @@
 '''Convert between BIP files and various image formats.'''
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'


### PR DESCRIPTION
- Python exe is gathered correctly on older Blender versions.
- Adjusted Install Pillow report messages.
- Import Image module if another addon installed PIL.